### PR TITLE
Cell matrix shape with nonempty_domain

### DIFF
--- a/src/cellarr/CellArrDataset.py
+++ b/src/cellarr/CellArrDataset.py
@@ -442,7 +442,10 @@ class CellArrDataset:
     ####
     @property
     def shape(self):
-        return (self._cell_metadata_tdb.shape[0], self._gene_annotation_tdb.shape[0])
+        return (
+            self._cell_metadata_tdb.nonempty_domain()[0][1] + 1,
+            self._gene_annotation_tdb.nonempty_domain()[0][1] + 1,
+        )
 
     def __len__(self):
         return self.shape[0]

--- a/src/cellarr/dataloader.py
+++ b/src/cellarr/dataloader.py
@@ -254,8 +254,8 @@ class DataModule(pl.LightningDataModule):
         )
 
         self.matrix_shape = (
-            self.cell_metadata_tdb.shape[0],
-            self.gene_annotation_tdb.shape[0],
+            self.cell_metadata_tdb.nonempty_domain()[0][1] + 1,
+            self.gene_annotation_tdb.nonempty_domain()[0][1] + 1,
         )
 
         # limit to cells with labels


### PR DESCRIPTION
Use nonempty_domain to get shapes in case using append mode