### PR TITLE
dataloader refactor

### DIFF
--- a/src/cellarr/autoencoder.py
+++ b/src/cellarr/autoencoder.py
@@ -334,7 +334,7 @@ class AutoEncoder(pl.LightningModule):
             The training loss
         """
 
-        cells, labels, studies = batch
+        cells, labels, studies, samples = batch
         embedding, reconstruction = self(cells)
         return self.mse_loss_fn(cells, reconstruction)
 

--- a/src/cellarr/dataloader.py
+++ b/src/cellarr/dataloader.py
@@ -353,7 +353,7 @@ class DataModule(LightningDataModule):
             # limit validation celltypes to those in the training data
             self.val_df = self.val_df[
                 self.val_df[self.label_column_name].isin(
-                    self.data_df[self.label_column_name].unique()
+                    self.train_df[self.label_column_name].unique()
                 )
             ]
         else:

--- a/src/cellarr/dataloader.py
+++ b/src/cellarr/dataloader.py
@@ -29,16 +29,15 @@ Example:
 """
 
 import os
-from collections import Counter
 from typing import List, Optional
 
 import numpy as np
 import pandas
 import tiledb
-from torch import squeeze, Tensor
+from torch import Tensor
 from pytorch_lightning import LightningDataModule
 import random
-from scipy.sparse import coo_matrix, csr_matrix
+from scipy.sparse import coo_matrix
 from torch.utils.data import DataLoader, Dataset
 
 from .queryutils_tiledb_frame import subset_frame

--- a/src/cellarr/dataloader.py
+++ b/src/cellarr/dataloader.py
@@ -410,7 +410,7 @@ class DataModule(LightningDataModule):
             # normalize the rows to sum to 1
             normalized_matrix = inv_row_sums.dot(X)
             # scale the rows sum to target_sum
-            X = normalized_matrix.multiply(datamodule.target_sum)
+            X = normalized_matrix.multiply(self.target_sum)
             X = X.log1p()
 
         X = Tensor(X.toarray())

--- a/tests/test_dataloader.py
+++ b/tests/test_dataloader.py
@@ -126,8 +126,8 @@ def test_autoencoder():
         sample_size=10,
         lognorm=True,
         target_sum=1e4,
-        #sampling_by_class=True,
-        #remove_singleton_classes=True,
+        # sampling_by_class=True,
+        # remove_singleton_classes=True,
     )
     print(datamodule)
 

--- a/tests/test_dataloader.py
+++ b/tests/test_dataloader.py
@@ -47,7 +47,7 @@ def test_dataloader():
     adata1 = generate_adata(1000, 100, study="test1", sample="a")
     adata2 = generate_adata(100, 1000, study="test2", sample="b")
     adata3 = generate_adata(100, 100, study="test3", sample="c")
-    adata4 = generate_adata(1000, 100, study="test4", sample="a")
+    adata4 = generate_adata(1000, 100, study="test4", sample="d")
     obs = pd.concat([adata1.obs, adata2.obs, adata3.obs, adata4.obs])
     obs = obs.reset_index(drop=True)
 
@@ -98,8 +98,7 @@ def test_autoencoder():
     adata1 = generate_adata(1000, 100, study="test1", sample="a")
     adata2 = generate_adata(100, 1000, study="test2", sample="b")
     adata3 = generate_adata(100, 100, study="test3", sample="c")
-    adata4 = generate_adata(1000, 100, study="test4", sample="a")
-    adata4 = generate_adata(1000, 100, study="test4", sample="a")
+    adata4 = generate_adata(1000, 100, study="test4", sample="d")
     obs = pd.concat([adata1.obs, adata2.obs, adata3.obs, adata4.obs])
     obs = obs.reset_index(drop=True)
 

--- a/tests/test_dataloader.py
+++ b/tests/test_dataloader.py
@@ -21,7 +21,7 @@ __copyright__ = "Jayaram Kancherla"
 __license__ = "MIT"
 
 
-def generate_adata(n, d, study):
+def generate_adata(n, d, study, sample):
     np.random.seed(1)
 
     y = (100 * rand(n, d, density=0.2, format="csr")).astype(int)
@@ -31,6 +31,7 @@ def generate_adata(n, d, study):
 
     obs_df = pd.DataFrame({"cells": [f"cell_{j+1}" for j in range(n)]})
     obs_df["study"] = study
+    obs_df["cellarr_sample"] = sample
     labels = [f"label_{i}" for i in range(10)] + [np.nan]
     obs_df["label"] = random.choices(labels, k=n)
     obs_df["index_in_file"] = range(n)
@@ -43,15 +44,19 @@ def generate_adata(n, d, study):
 def test_dataloader():
     tempdir = tempfile.mkdtemp()
 
-    adata1 = generate_adata(1000, 100, study="test1")
-    adata2 = generate_adata(100, 1000, study="test2")
-    adata3 = generate_adata(100, 100, study="test3")
-    obs = pd.concat([adata1.obs, adata2.obs, adata3.obs])
+    adata1 = generate_adata(1000, 100, study="test1", sample="a")
+    adata2 = generate_adata(100, 1000, study="test2", sample="b")
+    adata3 = generate_adata(100, 100, study="test3", sample="c")
+    adata4 = generate_adata(1000, 100, study="test4", sample="a")
+    obs = pd.concat([adata1.obs, adata2.obs, adata3.obs, adata4.obs])
     obs = obs.reset_index(drop=True)
+
+    sample_metadata = obs[["study", "cellarr_sample"]].drop_duplicates()
 
     build_cellarrdataset(
         output_path=tempdir,
-        files=[adata1, adata2, adata3],
+        files=[adata1, adata2, adata3, adata4],
+        sample_metadata=sample_metadata,
         cell_metadata=obs,
         matrix_options=MatrixOptions(dtype=np.float32),
     )
@@ -64,9 +69,13 @@ def test_dataloader():
         val_studies=["test3"],
         label_column_name="label",
         study_column_name="study",
-        batch_size=100,
+        sample_column_name="cellarr_sample",
+        batch_size=3,
+        sample_size=10,
         lognorm=True,
         target_sum=1e4,
+        sampling_by_class=True,
+        remove_singleton_classes=True,
     )
 
     assert "test1" in datamodule.data_df["study"].values
@@ -76,25 +85,30 @@ def test_dataloader():
 
     dataloader = datamodule.train_dataloader()
     batch = next(iter(dataloader))
-    data, labels, studies = batch
-    print(data, labels, studies)
-    assert len(labels) == 100
-    assert len(studies) == 100
-    assert data.shape == (100, len(datamodule.gene_indices))
+    data, labels, studies, samples = batch
+    print(data, labels, studies, samples)
+    assert data.shape == (30, len(datamodule.gene_indices))
+    assert len(labels) == 30
+    assert len(set(samples)) == 3
 
 
 def test_autoencoder():
     tempdir = tempfile.mkdtemp()
 
-    adata1 = generate_adata(1000, 100, study="test1")
-    adata2 = generate_adata(100, 1000, study="test2")
-    adata3 = generate_adata(100, 100, study="test3")
-    obs = pd.concat([adata1.obs, adata2.obs, adata3.obs])
+    adata1 = generate_adata(1000, 100, study="test1", sample="a")
+    adata2 = generate_adata(100, 1000, study="test2", sample="b")
+    adata3 = generate_adata(100, 100, study="test3", sample="c")
+    adata4 = generate_adata(1000, 100, study="test4", sample="a")
+    adata4 = generate_adata(1000, 100, study="test4", sample="a")
+    obs = pd.concat([adata1.obs, adata2.obs, adata3.obs, adata4.obs])
     obs = obs.reset_index(drop=True)
+
+    sample_metadata = obs[["study", "cellarr_sample"]].drop_duplicates()
 
     build_cellarrdataset(
         output_path=tempdir,
-        files=[adata1, adata2, adata3],
+        files=[adata1, adata2, adata3, adata4],
+        sample_metadata=sample_metadata,
         cell_metadata=obs,
         matrix_options=MatrixOptions(dtype=np.float32),
     )
@@ -107,9 +121,13 @@ def test_autoencoder():
         val_studies=["test3"],
         label_column_name="label",
         study_column_name="study",
-        batch_size=100,
+        sample_column_name="cellarr_sample",
+        batch_size=3,
+        sample_size=10,
         lognorm=True,
         target_sum=1e4,
+        sampling_by_class=True,
+        remove_singleton_classes=True,
     )
 
     autoencoder = AutoEncoder(
@@ -132,3 +150,11 @@ def test_autoencoder():
     autoencoder.save_all(model_path=os.path.join(tempdir, "test"))
     assert os.path.isfile(os.path.join(tempdir, "test", "encoder.ckpt"))
     assert os.path.isfile(os.path.join(tempdir, "test", "decoder.ckpt"))
+
+
+def main():
+    test_dataloader()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_dataloader.py
+++ b/tests/test_dataloader.py
@@ -78,9 +78,9 @@ def test_dataloader():
         remove_singleton_classes=True,
     )
 
-    assert "test1" in datamodule.data_df["study"].values
-    assert "test2" in datamodule.data_df["study"].values
-    assert "test3" not in datamodule.data_df["study"].values
+    assert "test1" in datamodule.train_df["study"].values
+    assert "test2" in datamodule.train_df["study"].values
+    assert "test3" not in datamodule.train_df["study"].values
     assert "test3" in datamodule.val_df["study"].values
 
     dataloader = datamodule.train_dataloader()

--- a/tests/test_dataloader.py
+++ b/tests/test_dataloader.py
@@ -126,9 +126,10 @@ def test_autoencoder():
         sample_size=10,
         lognorm=True,
         target_sum=1e4,
-        sampling_by_class=True,
-        remove_singleton_classes=True,
+        #sampling_by_class=True,
+        #remove_singleton_classes=True,
     )
+    print(datamodule)
 
     autoencoder = AutoEncoder(
         n_genes=len(datamodule.gene_indices),
@@ -141,7 +142,7 @@ def test_autoencoder():
 
     params = {
         "max_epochs": 2,
-        "logger": True,
+        "logger": False,
         "log_every_n_steps": 1,
         "limit_train_batches": 4,
     }
@@ -154,6 +155,7 @@ def test_autoencoder():
 
 def main():
     test_dataloader()
+    test_autoencoder()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Put all the tiledb access in collate so access only happens once per batch.
Switch to a sample based traditional epoch rather than cell multiset batches.
Set multiprocessing context to "spawn" for thread safety in DataLoader.